### PR TITLE
个人中心密码设置改动

### DIFF
--- a/src/java/com/bupt/ctrl/controller/UserController.java
+++ b/src/java/com/bupt/ctrl/controller/UserController.java
@@ -100,10 +100,11 @@ public class UserController {
                                        User user, HttpSession session){
         user = userService.getUserByID(uid);
 
-        ModelAndView mav = new ModelAndView("redirect:/user-setting.jsp");
+        ModelAndView mav = new ModelAndView("redirect:/index.jsp");
         user.setUserPassword(newPassword);
         userService.updateUser(user);
-        session.setAttribute("user.userPassword",newPassword);
+        session.setAttribute("user",user);
+        outLogin(session);
 
         return mav;
     }

--- a/src/java/com/bupt/ctrl/controller/UserController.java
+++ b/src/java/com/bupt/ctrl/controller/UserController.java
@@ -101,13 +101,10 @@ public class UserController {
         user = userService.getUserByID(uid);
 
         ModelAndView mav = new ModelAndView("redirect:/user-setting.jsp");
-        if(!oldPassword.equals(user.getUserPassword())){
-            mav.setViewName("redirect:/passwordReset_failure.jsp");//登录失败跳转到失败界面
-        }else{
-            user.setUserPassword(newPassword);
-            userService.updateUser(user);
-            session.setAttribute("user.userPassword",newPassword);
-        }
+        user.setUserPassword(newPassword);
+        userService.updateUser(user);
+        session.setAttribute("user.userPassword",newPassword);
+
         return mav;
     }
 

--- a/src/main/webapp/user-setting.jsp
+++ b/src/main/webapp/user-setting.jsp
@@ -11,14 +11,11 @@
             var oldPassword = document.getElementById("oldPassword").value;
             var newPassword = document.getElementById("newPassword").value;
             var newPassword2 = document.getElementById("newPassword2").value;
-            if (newPassword != newPassword2) {
-                alert("两次输入的密码不一致，请重新输入！");
+            if (oldPassword != ${sessionScope.user.userPassword}) {
+                alert("凑弟弟你密码输错了");
                 return false;
-            } else if (newPassword.length <= 2 || newPassword.length >= 19) {
-                alert("密码长度不合规范，请重新输入！");
-                return false;
-            } else if (oldPassword != ${sessionScope.user.userName}) {
-                alert("${sessionScope.user.userName}");
+            } else if (newPassword != newPassword2) {
+                alert("确认密码都确认不来你是真滴⑧太行");
                 return false;
             } else {
                 return true;


### PR DESCRIPTION
修正在个人中心多次修改密码时验证原始密码总会与第一次修改时的原始密码比对的bug，并且现在修改密码后会注销并跳转到主页
修改密码设置错误提示方式为模态框